### PR TITLE
Override setText to reset background bounds

### DIFF
--- a/transparent-text-textview/src/main/java/it/gilvegliach/android/transparenttexttextview/TransparentTextTextView.java
+++ b/transparent-text-textview/src/main/java/it/gilvegliach/android/transparenttexttextview/TransparentTextTextView.java
@@ -17,21 +17,16 @@
 package it.gilvegliach.android.transparenttexttextview;
 
 import android.annotation.SuppressLint;
-
 import android.content.Context;
-
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
-
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-
 import android.util.AttributeSet;
-
 import android.widget.TextView;
 
 public class TransparentTextTextView extends TextView {
@@ -114,5 +109,11 @@ public class TransparentTextTextView extends TextView {
     private void drawMask() {
         mMaskCanvas.drawColor(Color.BLACK, PorterDuff.Mode.CLEAR);
         super.onDraw(mMaskCanvas);
+    }
+
+    @Override
+    public void setText(CharSequence text, BufferType type) {
+        mSetBoundsOnSizeAvailable = true;
+        super.setText(text, type);
     }
 }


### PR DESCRIPTION
When this view is used in a RecyclerView and we have to update the text constantly, the background does not get updated properly which makes it appear cut when the new text is bigger than the previous one. This pull request fixes that.
